### PR TITLE
Update varnish to 5.1.2

### DIFF
--- a/varnish/Makefile
+++ b/varnish/Makefile
@@ -1,6 +1,6 @@
 # $NetBSD$
 
-DISTNAME=	varnish-5.1.1
+DISTNAME=	varnish-5.1.2
 
 .include "../../wip/varnish/Makefile.common"
 .include "../../mk/bsd.pkg.mk"

--- a/varnish/Makefile.common
+++ b/varnish/Makefile.common
@@ -17,6 +17,7 @@ USE_LIBTOOL=	yes
 USE_TOOLS+=	pkg-config gmake
 
 BUILD_DEFS+=	VARBASE
+BUILD_DEFS+=	PKG_SYSCONFBASE
 
 CONF_FILES=		share/examples/varnish/builtin.vcl \
 			${PKG_SYSCONFDIR}/builtin.vcl

--- a/varnish/distinfo
+++ b/varnish/distinfo
@@ -1,8 +1,8 @@
 $NetBSD: distinfo,v 1.13 2015/03/09 00:47:05 mspo Exp $
 
-SHA1 (varnish-5.1.1.tar.gz) = 585f0e5d45b349589de8da524037503d01f0ed59
-RMD160 (varnish-5.1.1.tar.gz) = eceb39a878be7ae6f2f62d2831e18bde47deb1ab
-SHA512 (varnish-5.1.1.tar.gz) = d5acb1fa9d55f5bb77bea85a6db637769126b701c010cffd511e8ac9fd67853e7f0d3bf86ba1ff067031e14a320b3bc9a84c66cd4a5a6b66d30226f5184f5f05
-Size (varnish-5.1.1.tar.gz) = 2589250 bytes
+SHA1 (varnish-5.1.2.tar.gz) = 602f5d4852385402f16e130049fb19c027da0b1c
+RMD160 (varnish-5.1.2.tar.gz) = 99adb4b130cd3446c109f8d9f6fc1d886bc66803
+SHA512 (varnish-5.1.2.tar.gz) = 6ee71c2678a34f7e3963547d8e79bd83e3b326ffe703ad60f0d6f8f218a3801849c870aa00e407008ef22cd2b2baf4cbe02625ce77018279afdb8208d43a743b
+Size (varnish-5.1.2.tar.gz) = 2597817 bytes
 SHA1 (patch-bin_varnishd_cache_cache__panic.c) = 08958f54c5ec5d70d9aa7fcbcf8fb97ce35533fa
 SHA1 (patch-etc_Makefile.in) = 02e500aeae7c3b293ddcf7d3ab8f03d7a267010f


### PR DESCRIPTION
================================
Varnish Cache 5.1.2 (2017-04-07)
================================

* Fix an endless loop in Backend Polling (#2295)

* Fix a Chunked bug in tight workspaces (#2207, #2275)

* Fix a bug relating to req.body when on waitinglist (#2266)

* Handle EPIPE on broken TCP connections (#2267)

* Work around the x86 arch's turbo-double FP format in parameter
  setup code. (#1875)

* Fix race related to backend probe with proxy header (#2278)

* Keep VCL temperature consistent between mgt/worker also when
  worker protests.

* A lot of HTTP/2 fixes.
