### PR TITLE
Update wip/rtl_433 to latest.

### DIFF
--- a/rtl_433/Makefile
+++ b/rtl_433/Makefile
@@ -1,10 +1,10 @@
 # $NetBSD$
 
 GITHUB_PROJECT=	rtl_433
-GITHUB_TAG=	21.05
-DISTNAME=	21.05
+GITHUB_TAG=	23.11
+DISTNAME=	23.11
 PKGNAME=	${GITHUB_PROJECT}-${DISTNAME}
-PKGREVISION=	1
+PKGREVISION=	
 CATEGORIES=	ham
 MASTER_SITES=	${MASTER_SITE_GITHUB:=merbanan/}
 DIST_SUBDIR=	${GITHUB_PROJECT}
@@ -37,4 +37,5 @@ post-install:
 
 .include "options.mk"
 .include "../../devel/libusb1/buildlink3.mk"
+.include "../../security/openssl/buildlink3.mk"
 .include "../../mk/bsd.pkg.mk"

--- a/rtl_433/PLIST
+++ b/rtl_433/PLIST
@@ -1,12 +1,22 @@
 @comment $NetBSD$
 bin/rtl_433
 etc/rtl_433/CAME-TOP432.conf
+etc/rtl_433/ContinentalRemote.conf
+etc/rtl_433/DrivewayAlarm_I8-W1901.conf
+etc/rtl_433/DrivewayAlert.conf
 etc/rtl_433/EV1527-4Button-Universal-Remote.conf
+etc/rtl_433/EV1527-DDS-Sgooway.conf
 etc/rtl_433/EV1527-PIR-Sgooway.conf
 etc/rtl_433/FAN-53T.conf
+etc/rtl_433/GhostControls.conf
 etc/rtl_433/HeatmiserPRT-W.conf
+etc/rtl_433/LeakDetector.conf
 etc/rtl_433/MightyMule-FM231.conf
+etc/rtl_433/MondeoRemote.conf
+etc/rtl_433/PHOX.conf
+etc/rtl_433/Reolink-doorbell.conf
 etc/rtl_433/SMC5326-Remote.conf
+etc/rtl_433/SWETUP-garage-opener.conf
 etc/rtl_433/SalusRT300RF.conf
 etc/rtl_433/Skylink_HA-434TL.conf
 etc/rtl_433/adlm_fprf.conf
@@ -14,9 +24,13 @@ etc/rtl_433/atc-technology_lmt-430.conf
 etc/rtl_433/car_fob.conf
 etc/rtl_433/chungear_bcf-0019x2.conf
 etc/rtl_433/dooya_curtain.conf
+etc/rtl_433/elro_ab440r.conf
 etc/rtl_433/energy_count_3000.conf
 etc/rtl_433/fan-11t.conf
 etc/rtl_433/friedlandevo.conf
+etc/rtl_433/ge_smartremote_plus.conf
+etc/rtl_433/heatilator.conf
+etc/rtl_433/honeywell-fan.conf
 etc/rtl_433/led-light-remote.conf
 etc/rtl_433/pir-ef4.conf
 etc/rtl_433/rtl_433.example.conf
@@ -24,8 +38,10 @@ etc/rtl_433/silverline_doorbell.conf
 etc/rtl_433/sonoff_rm433.conf
 etc/rtl_433/steffen_switch.conf
 etc/rtl_433/tesla_charge-port-opener.conf
+etc/rtl_433/tyreguard400.conf
 etc/rtl_433/valeo_car_key.conf
 etc/rtl_433/verisure_alarm.conf
+etc/rtl_433/xmas-tree-remote-2APJZ-CW002.conf
 include/rtl_433.h
 include/rtl_433_devices.h
 man/man1/rtl_433.1


### PR DESCRIPTION
Updates rtl_433 from 21.05 (released 2021-May-09) to 23.11 (released 2023-Nov-28). Includes 10 additional sample config files. Had to include buildlink for OpenSSL to build.