### PR TITLE
iravoice: Add version 0.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1826,6 +1826,7 @@ SUBDIR+=	ipax0208font-ttf
 SUBDIR+=	ipsvd
 SUBDIR+=	iptables
 SUBDIR+=	iptstate
+SUBDIR+=	iravoice
 SUBDIR+=	ircII-current
 SUBDIR+=	irixjoker-ai-utils
 SUBDIR+=	ironpython

--- a/iravoice/COMMIT_MSG
+++ b/iravoice/COMMIT_MSG
@@ -1,0 +1,9 @@
+misc/iravoice: Add iravoice version 0.7.2
+
+Packaged in wip by IraVoice Founder.
+
+The package installs the signed, notarized Apple-silicon app from the
+stable upstream DMG. Binary package redistribution is disabled; the
+unmodified distfile may be mirrored under the upstream PAD terms.
+
+IraVoice is a private, on-device dictation app for macOS 26 or later.

--- a/iravoice/DESCR
+++ b/iravoice/DESCR
@@ -1,0 +1,4 @@
+IraVoice is a private dictation app for Apple-silicon Macs.
+
+It performs speech recognition on-device and installs as a notarized
+macOS app bundle in the pkgsrc Applications directory.

--- a/iravoice/Makefile
+++ b/iravoice/Makefile
@@ -1,0 +1,43 @@
+# $NetBSD$
+
+DISTNAME=	IraVoice-0.7.2
+PKGNAME=	iravoice-0.7.2
+CATEGORIES=	misc
+MASTER_SITES=	https://iravoice.com/downloads/
+EXTRACT_SUFX=	.dmg
+
+MAINTAINER=	hello@iravoice.com
+HOMEPAGE=	https://iravoice.com/
+COMMENT=	Private on-device dictation app for Apple-silicon Macs
+LICENSE=	iravoice-license-20260724
+
+# PAD line 96 permits software catalogs to mirror the original notarized DMG,
+# but forbids repackaging, bundling, or modification. That allows distfile
+# mirroring while still prohibiting redistribution of the pkgsrc binary package.
+LICENSE_FILE=		${FILESDIR}/iravoice-license-20260724
+RESTRICTED=		PAD permits mirroring only the unmodified official DMG
+NO_BIN_ON_CDROM=	${RESTRICTED}
+NO_BIN_ON_FTP=		${RESTRICTED}
+
+NO_BUILD=		yes
+NO_CONFIGURE=		yes
+EXTRACT_ONLY=		# empty
+INSTALL_UNSTRIPPED=	yes
+
+# LSMinimumSystemVersion is 26.0, which corresponds to Darwin 25.
+NOT_FOR_PLATFORM=	Darwin-[0-9].*-aarch64 Darwin-1[0-9].*-aarch64 Darwin-2[0-4].*-aarch64
+ONLY_FOR_PLATFORM=	Darwin-*-aarch64
+
+USE_LANGUAGES=		# none
+USE_TOOLS+=		pax
+
+INSTALLATION_DIRS+=	Applications
+CHECK_SHLIBS_SKIP+=	Applications/IraVoice.app/Contents/MacOS/IraVoice
+
+do-install:
+	${SH} ${FILESDIR}/install-dmg.sh \
+		${DISTDIR}/${DISTNAME}${EXTRACT_SUFX} \
+		${DESTDIR}${PREFIX}/Applications \
+		${WRKDIR}
+
+.include "../../mk/bsd.pkg.mk"

--- a/iravoice/PLIST
+++ b/iravoice/PLIST
@@ -1,0 +1,6 @@
+@comment $NetBSD$
+Applications/IraVoice.app/Contents/CodeResources
+Applications/IraVoice.app/Contents/Info.plist
+Applications/IraVoice.app/Contents/MacOS/IraVoice
+Applications/IraVoice.app/Contents/Resources/AppIcon.icns
+Applications/IraVoice.app/Contents/_CodeSignature/CodeResources

--- a/iravoice/distinfo
+++ b/iravoice/distinfo
@@ -1,0 +1,5 @@
+$NetBSD$
+
+BLAKE2s (IraVoice-0.7.2.dmg) = 907e5cf4bba9198baf8f80d21655a3665971f2be9bc7941e5fdb76fb46bdf8bf
+SHA512 (IraVoice-0.7.2.dmg) = 79af752b171231cd4f5fa9a7af9086e290c0c963c3ed5672dc5c83c8a41ca266bc7f685052f1d6422c00ffdcd634da47a5262b2a658a4531c5f5eced70463146
+Size (IraVoice-0.7.2.dmg) = 1791569 bytes

--- a/iravoice/files/install-dmg.sh
+++ b/iravoice/files/install-dmg.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -eu
+
+distfile=$1
+destination=$2
+workdir=$3
+mountpoint="${workdir}/IraVoice.dmg.mnt"
+device=
+
+cleanup()
+{
+	if [ -n "${device}" ]; then
+		/usr/bin/hdiutil detach "${device}" >/dev/null 2>&1 ||
+			/usr/bin/hdiutil detach -force "${device}" >/dev/null 2>&1 ||
+			true
+	fi
+	rmdir "${mountpoint}" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "${mountpoint}"
+device=$(/usr/bin/hdiutil attach -nobrowse -readonly \
+	-mountpoint "${mountpoint}" "${distfile}" |
+	awk -v mp="${mountpoint}" '$NF == mp { print $1; exit }')
+test -n "${device}"
+
+cd "${mountpoint}"
+pax -rw -pp -pm IraVoice.app "${destination}"

--- a/iravoice/files/iravoice-license-20260724
+++ b/iravoice/files/iravoice-license-20260724
@@ -1,0 +1,35 @@
+IraVoice for Mac Terms
+Effective July 24, 2026
+Source: https://iravoice.com/terms
+
+License
+
+A paid IraVoice license grants the buyer a personal, non-transferable
+right to use the app. You may not redistribute the app or share a
+license key publicly.
+
+Trial and payment
+
+The full-feature trial lasts 3 days and does not require a card. Paid
+licenses are sold for a one-time $50 payment through Gumroad, which
+handles checkout, tax collection, receipts, refunds, and key delivery.
+
+Refunds
+
+The current Gumroad checkout includes a 30-day money-back guarantee.
+Refund requests are handled through Gumroad and may revoke the
+associated license.
+
+Software
+
+IraVoice is provided as-is. Keep a backup of important work and review
+inserted text before relying on it. You remain responsible for what you
+send, publish, or execute.
+
+Distribution permissions
+
+Source: https://iravoice.com/pad/iravoice.xml
+
+Software catalogs may link to or mirror the unmodified official signed
+and Apple-notarized DMG. Do not repackage, bundle, modify, or add
+installers, offers, or tracking to the application.


### PR DESCRIPTION
Adds IraVoice 0.7.2, a private on-device dictation app for Apple-silicon Macs running macOS 26 or later.

The package installs the existing signed and Apple-notarized app from the stable upstream DMG. The original DMG may be mirrored under the upstream PAD terms, while `RESTRICTED`, `NO_BIN_ON_CDROM`, and `NO_BIN_ON_FTP` prevent distribution of repackaged pkgsrc binary archives.

Validation completed on aarch64 Darwin:

- `pkglint -Wall -i`: clean
- distfile BLAKE2s and SHA512 checks: pass
- clean package build: pass
- package file-list check: pass
- DMG mount cleanup: pass, with no leaked mount
- extracted packaged app: `codesign --verify --deep --strict` passes
- Gatekeeper: accepted as Notarized Developer ID

Homepage: https://iravoice.com/
PAD distribution terms: https://iravoice.com/pad/iravoice.xml